### PR TITLE
Allow consumers of `tapes` to patch the core `tape` library

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,9 @@ test.skip = function (name, fn, _before, _after) {
   return test(name, fn, _before, _after, false, true);
 };
 
+// Allow consumers of `tapes` to patch the core `tape` library.
+test.Test = tape.Test;
+
 function runWrapperFns (fns, callback) {
   callback = callback || function () {};
 


### PR DESCRIPTION
`tapes` is a great extension to `tape`, however, sometimes it is nice to be able to monkeypatch `tape` itself.