### PR TITLE
Support top-level beforeEach and afterEach handlers, without requiring creating a set of tests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,30 +6,70 @@ function tapes (tape, opts) {
   // Allow consumers of `tapes` to patch the core `tape` library.
   test.Test = tape.Test;
 
+  var before = [];
+  var after = [];
+
   delimiter = opts && opts.delimiter || ' ';
 
-  test.only = function (name, fn, _before, _after) {
-    return test(name, fn, _before, _after, true);
+  testRunner.only = function (name, fn, _before, _after) {
+    return test(tape, name, fn, _before, _after, true);
   };
 
-  test.skip = function (name, fn, _before, _after) {
-    return test(name, fn, _before, _after, false, true);
+  testRunner.skip = function (name, fn, _before, _after) {
+    return test(tape, name, fn, _before, _after, false, true);
   };
 
-  return function (name, fn, _before, _after, only) {
-    return test(tape, name, fn, _before, _after, only);
+  testRunner.beforeEach = function (fn) {
+    before.push(fn);
   };
+
+  testRunner.afterEach = function (fn) {
+    after.push(fn);
+  };
+
+  function testRunner(name, fn, _before, _after, only, skip) {
+    if (_before) {
+      before.concat(_before);
+    }
+    if (_after) {
+      after.concat(_after);
+    }
+    test(tape, name, fn, before, after, only);
+  };
+
+  return testRunner;
 }
 
 function test (tape, name, fn, _before, _after, only, skip) {
   var before = _before || [];
   var after = _after || [];
-  var testFn = only
+  var tapeTest = only
     ? tape.only
     : skip ? tape.skip : tape;
 
-  testFn(name, function (t) {
+  tapeTest(name, function (t) {
     var tEnd = t.end.bind(t);
+    var tPlan = t.plan.bind(t);
+    var executedAfters = false;
+
+    t.end = function () {
+      runWrapperFns(after, function () {
+        executedAfters = true;
+        tEnd();
+      });
+    };
+
+    t.plan = function (numberofAssertions) {
+      tPlan(numberofAssertions);
+    };
+
+    t.on('end', function (num) {
+      if (!executedAfters) {
+        runWrapperFns(after, function () {
+          executedAfters = true;
+        });
+      }
+    });
 
     t.beforeEach = function (fn) {
       before.push(fn);
@@ -40,42 +80,19 @@ function test (tape, name, fn, _before, _after, only, skip) {
     };
 
     t.test = function (tName, tFn, only, skip) {
-      var tTestFn = only
+      var tapesTest = only
         ? test.only
         : skip ? test.skip : test;
 
-      tTestFn(tape, name + delimiter + tName, function (q) {
-        var qEnd = q.end.bind(q);
-        var qPlan = q.plan.bind(q);
-        var executedAfters = false;
-
-        q.end = function () {
-          runWrapperFns(after, function () {
-            executedAfters = true;
-            qEnd();
-          });
-        };
-
-        q.plan = function (numberofAssertions) {
-          qPlan(numberofAssertions);
-        };
-
-        q.on('end', function (num) {
-          if (!executedAfters) runWrapperFns(after, function () {
-            executedAfters = true;
-          });
-        });
-
-        tFn(q);
-      }, before.slice(0), after.slice(0));
+      tapesTest(tape, name + delimiter + tName, tFn, before.slice(0), after.slice(0));
     };
 
     t.test.only = function (tName, tFn) {
-      return t.test(tName, tFn, true);
+      t.test(tName, tFn, true);
     };
 
     t.test.skip = function (tName, tFn) {
-      return t.test(tName, tFn, false, true);
+      t.test(tName, tFn, false, true);
     };
 
     runWrapperFns(before, function () {

--- a/test/set-handlers.js
+++ b/test/set-handlers.js
@@ -1,0 +1,44 @@
+var tape = require('tape');
+var tapes = require('../');
+var test = tapes(tape);
+
+var beforeRan = false;
+var afterRan = false;
+
+test.beforeEach(function(t) {
+  beforeRan = true;
+  t.end();
+});
+
+test.afterEach(function (t) {
+  afterRan = true;
+  t.end();
+});
+
+test('set', function(t) {
+  var setBeforeRan = false;
+  var setAfterRan = false;
+
+  t.beforeEach(function (t) {
+    setBeforeRan = true;
+    t.end();
+  });
+
+  t.afterEach(function (t) {
+    setAfterRan = true;
+    t.end();
+  });
+
+  t.test('test1', function(t) {
+    t.true(beforeRan, 'A beforeEach function ran for this set.');
+    t.true(setBeforeRan, 'A beforeEach function ran for this test.');
+    t.end();
+  });
+
+  t.test('test2', function(t) {
+    t.true(setAfterRan, 'An afterEach function ran for test1');
+    t.end();
+  });
+
+  t.end();
+});

--- a/test/top-level-handlers.js
+++ b/test/top-level-handlers.js
@@ -1,0 +1,27 @@
+var tape = require('tape');
+var tapes = require('../');
+var test = tapes(tape);
+
+var beforeRan = false;
+var afterRan = false;
+
+test.beforeEach(function (t) {
+  beforeRan = true;
+  t.end();
+});
+
+test.afterEach(function (t) {
+  afterRan = true;
+  t.end();
+});
+
+test('Top-level test1', function (t) {
+  t.true(beforeRan, 'A beforeEach function ran before I did.');
+  t.false(afterRan, 'No afterEach functions have run yet.');
+  t.end();
+});
+
+test('Top-level test2', function (t) {
+  t.true(afterRan, 'The previous test\'s afterEach function ran.');
+  t.end();
+});


### PR DESCRIPTION
I was really hoping to roll this into our tests without changing anything, but currently beforeEach and afterEach only work within a defined set of tests:

```
test('set1', function(t) {
  t.beforeEach(function(t) {
    // will execute before test1
    t.end();
  });
  t.afterEach(function(t) {
    // will execute after test1
    t.end();
  });
  
  t.test('test1', function(t) {
    t.ok();
    t.end();
  });
});
```

I, however, am lazy and don't want to have to wrap all of our tests within a set, resulting in a relatively huge diff, when really only a few lines at the beginning and end of each test ought to be affected (in addition to setting up the beforeEach/afterEach functions.) I expected something like this to be possible:


```
var tape = require('tape');
var tapes = require('../');
var test = tapes(tape);

t.beforeEach(function(t) {
  // will execute before test1
  t.end();
});
t.afterEach(function(t) {
  // will execute after test1
  t.end();
});

t.test('test1', function(t) {
  t.ok();
  t.end();
});
```

I forked the repo and tried to make the necessary changes, but there are some decisions that I found confusing - maybe they're for backwards compatibility with tape 3?

Some specific notes:

* Why are the `[tq]End` and `[tq]End` only bound inside the second-level `tTestFn` method? Why are the afterEach methods only run/checked there? This was the biggest change I made, moving them down, and while all the tests pass, they're by no means exhaustive.

* runWrapperFns is run over the set of afterEach functions in the `[tq]End` method, but there's also a conditional checkin the 'end' listener as well - it seems redundant to have both. Is this for backwards compatibility?

* I renamed some of your method names. `testFn` and `tTestFn` were confusing me, so I renamed them to marginally less confusing `tapeTest`, meaning that it's the actual test method from the `tape` library, and `tapesTest`, meaning that it's from _this_ module. It got a little easier to think about that way.

* I renamed the anonymous function to `testRunner`, so I could....

* ... move the `.only` and `.skip` overrides in the `tapes` function to the `testRunner` method, instead of the `test` method, so that top-level tests could also be skippable and only-able.

I've been a little sick this weekend, so I hope that this actually makes sense.